### PR TITLE
fix: check for stylesheets on current domain too

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -540,6 +540,10 @@ function serializeTextNode(
   };
 }
 
+function findStylesheet(doc: Document, href: string) {
+  return Array.from(doc.styleSheets).find((s) => s.href === href);
+}
+
 function serializeElementNode(
   n: HTMLElement,
   options: {
@@ -592,9 +596,14 @@ function serializeElementNode(
   // remote css
   if (tagName === 'link' && inlineStylesheet) {
     //TODO: maybe replace this `.styleSheets` with original one
-    const stylesheet = Array.from(doc.styleSheets).find((s) => {
-      return s.href === (n as HTMLLinkElement).href;
-    });
+    const href = (n as HTMLLinkElement).href;
+    let stylesheet = findStylesheet(doc, href);
+    if (!stylesheet && href.includes('.css')) {
+      const rootDomain = window.location.origin;
+      const stylesheetPath = href.replace(window.location.href, '');
+      const potentialStylesheetHref = rootDomain + '/' + stylesheetPath;
+      stylesheet = findStylesheet(doc, potentialStylesheetHref);
+    }
     let cssText: string | null = null;
     if (stylesheet) {
       cssText = stringifyStylesheet(stylesheet);


### PR DESCRIPTION
first added in https://github.com/PostHog/posthog-js/pull/1272 and https://github.com/PostHog/posthog-js/pull/1275

with original PR description there

----

## Problem

Relates to https://posthoghelp.zendesk.com/agent/tickets/14512 (and probably a bunch more support tickets)

This could also be related to https://github.com/rrweb-io/rrweb/issues/1230

Addresses an issue in recordings where styles were being dropped during some route changes in SPAs

### Reproduction
It's not fully clear to me how this happens or what the correct behaviour is but the problem exists when:

1. You have a relative link element on the page:
```
<link href="./_app/immutable/assets/filename.css" rel="stylesheet">
```
2. This gets loaded into the documents `styleSheets` array with the href set as `https://domainname.com/_app/immutable/assets/filename.css`

3. Sometime later the domain changes away from the index page to another root e.g. `https://domainname.com/home`
4. When taking the next full snapshot [rrweb tries to fetch the stylesheet associated with the href](https://github.com/rrweb-io/rrweb/blob/4f44bd17aa888c041e9a4c8c0f4c921af92a4b12/packages/rrweb-snapshot/src/snapshot.ts#L657-L659):
```
const stylesheet = Array.from(doc.styleSheets).find((s) => {
  return s.href === (n as HTMLLinkElement).href;
});
```
5. `n.href` now evaluates to `https://domainname.com/home/_app/immutable/assets/filename.css` which no longer matches the `href` of the stylesheet on the document and hence cannot be "found". Presumably the href on the document stylesheet does not change because the SPA is not doing a full page transition

## Changes

This PR adds a backup check to look for the CSS on the root of the domain
- It only does this for CSS files
- It only does the lookup if a stylesheet cannot initially be found

This feels like the safest change for now but will get the opinion of others in the rrweb community too
