### PR TITLE
fix: much better zone detection

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -28,22 +28,36 @@ const testableMethods = {
 
 const untaintedBasePrototype: Partial<BasePrototypeCache> = {};
 
-/*
- When angular patches things - particularly the MutationObserver -
- they pass the `isNativeFunction` check
- That then causes performance issues
- because Angular's change detection
- doesn't like sharing a mutation observer
- Checking for the presence of the Zone object
- on global is a good-enough proxy for Angular
- to cover most cases
- (you can configure zone.js to have a different name
-  on the global object and should then manually run rrweb
-  outside the Zone)
- */
-export const isAngularZonePresent = (): boolean => {
-  return !!(globalThis as { Zone?: unknown }).Zone;
+type WindowWithZone = typeof globalThis & {
+  Zone?: {
+    __symbol__?: (key: string) => string;
+  };
 };
+
+type WindowWithUnpatchedSymbols = typeof globalThis &
+  Record<string, TypeofPrototypeOwner>;
+
+/*
+Angular zone patches many things and can pass the untainted checks below, causing performance issues
+Angular zone, puts the unpatched originals on the window, and the names for hose on the zone object.
+So, we get the unpatched versions from the window object if they exist.
+You can rename Zone, but this is a good enough proxy to avoid going to an iframe to get the untainted versions.
+*/
+function angularZoneUnpatchedAlternative(key: keyof BasePrototypeCache) {
+  const angularUnpatchedVersionSymbol = (
+    globalThis as WindowWithZone
+  )?.Zone?.__symbol__?.(key);
+  if (
+    angularUnpatchedVersionSymbol &&
+    (globalThis as WindowWithUnpatchedSymbols)[angularUnpatchedVersionSymbol]
+  ) {
+    return (globalThis as WindowWithUnpatchedSymbols)[
+      angularUnpatchedVersionSymbol
+    ];
+  } else {
+    return undefined;
+  }
+}
 
 export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   key: T,
@@ -51,8 +65,9 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
   if (untaintedBasePrototype[key])
     return untaintedBasePrototype[key] as BasePrototypeCache[T];
 
-  const defaultObj = globalThis[key] as TypeofPrototypeOwner;
-  const defaultPrototype = defaultObj.prototype as BasePrototypeCache[T];
+  let candidate = globalThis[key] as TypeofPrototypeOwner;
+  candidate = angularZoneUnpatchedAlternative(key) || candidate;
+  const defaultPrototype = candidate.prototype as BasePrototypeCache[T];
 
   // use list of testable accessors to check if the prototype is tainted
   const accessorNames =
@@ -80,16 +95,16 @@ export function getUntaintedPrototype<T extends keyof BasePrototypeCache>(
       ),
   );
 
-  if (isUntaintedAccessors && isUntaintedMethods && !isAngularZonePresent()) {
-    untaintedBasePrototype[key] = defaultObj.prototype as BasePrototypeCache[T];
-    return defaultObj.prototype as BasePrototypeCache[T];
+  if (isUntaintedAccessors && isUntaintedMethods) {
+    untaintedBasePrototype[key] = candidate.prototype as BasePrototypeCache[T];
+    return candidate.prototype as BasePrototypeCache[T];
   }
 
   try {
     const iframeEl = document.createElement('iframe');
     document.body.appendChild(iframeEl);
     const win = iframeEl.contentWindow;
-    if (!win) return defaultObj.prototype as BasePrototypeCache[T];
+    if (!win) return candidate.prototype as BasePrototypeCache[T];
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     const untaintedObject = (win as any)[key]

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -42,6 +42,7 @@ Angular zone patches many things and can pass the untainted checks below, causin
 Angular zone, puts the unpatched originals on the window, and the names for hose on the zone object.
 So, we get the unpatched versions from the window object if they exist.
 You can rename Zone, but this is a good enough proxy to avoid going to an iframe to get the untainted versions.
+see: https://github.com/angular/angular/issues/26948
 */
 function angularZoneUnpatchedAlternative(key: keyof BasePrototypeCache) {
   const angularUnpatchedVersionSymbol = (


### PR DESCRIPTION
this is how Angular was detected in rrweb v1

in tests with a log when the observer fires, we don't see that log with current code and do see the log with this