### PR TITLE
chore: publish replayer to NPM so we can load it via unpkg for debugging

### DIFF
--- a/scripts/npm-release.sh
+++ b/scripts/npm-release.sh
@@ -6,6 +6,7 @@
 # assumes this is run with cwd as the root of the repo
   PACKAGES=(
     "./packages/record"
+    "./packages/replay"
     "./packages/plugins/rrweb-plugin-console-record"
     "./packages/types"
     "./packages/rrweb"


### PR DESCRIPTION
want to make a posthog clone of rrwebdebug.com so we can see how our recordings play in our build of the vanilla player
compared to the rrweb build

currently at https://pauldambra.dev/rrwebdebug.com/