### PR TITLE
fix: empty cdata should not throw

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -333,6 +333,10 @@ function buildNode(
           : n.textContent,
       );
     case NodeType.CDATA:
+      if (n.textContent.trim() === '') {
+        return null;
+      }
+
       return doc.createCDATASection(n.textContent);
     case NodeType.Comment:
       return doc.createComment(n.textContent);


### PR DESCRIPTION
in a customer recording we see an SVG with an empty CDATA section
this breaks the entire playback
but it shouldn't...