### PR TITLE
fix: missing nodes and parents perf

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1695,7 +1695,7 @@ export class Replayer {
 
       queue.length = 0;
 
-      if (performance.now() - startTime > 500) {
+      if (performance.now() - startTime > 150) {
         this.warn(
           'Timeout in the loop, please check the resolve tree data:',
           resolveTrees,


### PR DESCRIPTION
We periodically see reports where the browser freezes during playback.

Because the browser freezes it's super hard to investigate... but now we have https://posthog.github.io/rrwebdebug.com/

I've added the ability to debug with local builds of rrweb and tested with customer provided recordings

when processing a list of adds

we 

* call appendNode for each
* if the parent or nextid is not in the DOM we queue the mutation
* we build a tree of those mutations
* for each mutation in the tree we call appendNode

so if the nextId is not added to the DOM by the list of mutations, then we loop forever