### PR TITLE
fix: in applyStyleDeclaration during replay we `as unknown as` and explode

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2027,7 +2027,7 @@ export class Replayer {
         styleSheet.rules,
         data.index,
       ) as unknown as CSSStyleRule;
-      rule.style.removeProperty(data.remove.property);
+      rule?.style?.removeProperty(data.remove.property);
     }
   }
 

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2015,7 +2015,7 @@ export class Replayer {
         styleSheet.rules,
         data.index,
       ) as unknown as CSSStyleRule;
-      rule.style.setProperty(
+      rule?.style?.setProperty(
         data.set.property,
         data.set.value,
         data.set.priority,


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/34004

after forcing the typecast we treat the thing as if it is definitely present
it is not
and this caused errors during playback for user