### PR TITLE
fix: use node.baseURI for stringifying stylesheet hrefs

### DIFF
--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -111,7 +111,7 @@ export function stringifyStylesheet(s: CSSStyleSheet): string | null {
     let sheetHref = s.href;
     if (!sheetHref && s.ownerNode && s.ownerNode.ownerDocument) {
       // an inline <style> element
-      sheetHref = s.ownerNode.ownerDocument.baseURI;
+      sheetHref = s.ownerNode.baseURI;
     }
     const stringifiedRules = Array.from(rules, (rule: CSSRule) =>
       stringifyRule(rule, sheetHref),

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -109,7 +109,7 @@ export function stringifyStylesheet(s: CSSStyleSheet): string | null {
       return null;
     }
     let sheetHref = s.href;
-    if (!sheetHref && s.ownerNode && s.ownerNode.ownerDocument) {
+    if (!sheetHref && s.ownerNode) {
       // an inline <style> element
       sheetHref = s.ownerNode.baseURI;
     }

--- a/packages/rrweb-snapshot/test/utils.test.ts
+++ b/packages/rrweb-snapshot/test/utils.test.ts
@@ -303,7 +303,7 @@ describe('utils', () => {
       expect(stringifyStylesheet(mockSheet)).toBe('div { margin: 0; }');
     });
 
-    it('uses ownerNode.ownerDocument.baseURI for inline styles', () => {
+    it('uses ownerNode.baseURI for inline styles', () => {
       const mockFontFaceRule = {
         cssText: `
           @font-face {
@@ -314,12 +314,8 @@ describe('utils', () => {
           }
         `,
       } as CSSRule;
-      const mockOwnerDocument = {
-        location: { href: 'https://example.com/page.html' },
-        baseURI: 'https://example.com/fonts/',
-      } as unknown as Document;
       const mockOwnerNode = {
-        ownerDocument: mockOwnerDocument,
+        baseURI: 'https://example.com/fonts/',
       } as unknown as Node;
       const mockSheet = {
         cssRules: [mockFontFaceRule],


### PR DESCRIPTION
adopt https://github.com/rrweb-io/rrweb/pull/1705