### PR TITLE
fix: guard rrweb rebuild against invalid custom element names

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -89,6 +89,25 @@ export function createCache(): BuildCache {
   };
 }
 
+const reservedCustomElementNames = new Set([
+  'annotation-xml',
+  'color-profile',
+  'font-face',
+  'font-face-src',
+  'font-face-uri',
+  'font-face-format',
+  'font-face-name',
+  'missing-glyph',
+]);
+
+const validCustomElementName = /^[a-z][a-z0-9._-]*-[a-z0-9._-]*$/;
+
+function isValidCustomElementName(name: string): boolean {
+  if (typeof name !== 'string' || name.length === 0) return false;
+  if (reservedCustomElementNames.has(name)) return false;
+  return validCustomElementName.test(name);
+}
+
 function safeDocNode(
   n: textNode,
   options: {
@@ -141,13 +160,17 @@ function buildNode(
           n.isCustom &&
           // If the browser supports custom elements
           doc.defaultView?.customElements &&
+          isValidCustomElementName(n.tagName) &&
           // If the custom element hasn't been defined yet
           !doc.defaultView.customElements.get(n.tagName)
-        )
-          doc.defaultView.customElements.define(
-            n.tagName,
-            class extends doc.defaultView.HTMLElement {},
-          );
+        ) {
+          try {
+            doc.defaultView.customElements.define(
+              n.tagName,
+              class extends doc.defaultView.HTMLElement {},
+            );
+          } catch {}
+        }
         node = doc.createElement(tagName);
       }
       /**

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -100,13 +100,15 @@ const reservedCustomElementNames = new Set([
   'missing-glyph',
 ]);
 
-const validCustomElementName = /^[a-z][a-z0-9._-]*-[a-z0-9._-]*$/;
-
-function isValidCustomElementName(name: string): boolean {
+function isPlausibleCustomElementName(name: string): boolean {
   if (typeof name !== 'string' || name.length === 0) return false;
   if (reservedCustomElementNames.has(name)) return false;
-  return validCustomElementName.test(name);
+  if (!name.includes('-')) return false;
+  const first = name.charCodeAt(0);
+  return first >= 0x61 && first <= 0x7a;
 }
+
+const warnedCustomElementNames = new Set<string>();
 
 function safeDocNode(
   n: textNode,
@@ -160,7 +162,7 @@ function buildNode(
           n.isCustom &&
           // If the browser supports custom elements
           doc.defaultView?.customElements &&
-          isValidCustomElementName(n.tagName) &&
+          isPlausibleCustomElementName(n.tagName) &&
           // If the custom element hasn't been defined yet
           !doc.defaultView.customElements.get(n.tagName)
         ) {
@@ -169,7 +171,16 @@ function buildNode(
               n.tagName,
               class extends doc.defaultView.HTMLElement {},
             );
-          } catch {}
+          } catch (error) {
+            if (!warnedCustomElementNames.has(n.tagName)) {
+              warnedCustomElementNames.add(n.tagName);
+              console.warn(
+                'rrweb: failed to register custom element',
+                n.tagName,
+                error,
+              );
+            }
+          }
         }
         node = doc.createElement(tagName);
       }

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -669,14 +669,20 @@ ul li.specified c.\\:hover img {
       ['annotation-xml'],
       ['missing-glyph'],
       ['nohyphen'],
-    ])('does not throw and does not register when tagName is %p', (tagName) => {
-      expect(() => buildCustomElement(tagName)).not.toThrow();
-      expect(window.customElements.get(tagName)).toBeUndefined();
-    });
+    ])(
+      'does not throw, returns a usable HTMLElement, and does not register when tagName is %p',
+      (tagName) => {
+        let node: Node | null | undefined;
+        expect(() => {
+          node = buildCustomElement(tagName);
+        }).not.toThrow();
+        expect(node).toBeInstanceOf(window.HTMLElement);
+        expect(window.customElements.get(tagName)).toBeUndefined();
+      },
+    );
 
-    it('creates a plain element for invalid custom element names', () => {
+    it('keeps the original tagName for invalid custom element names', () => {
       const node = buildCustomElement('webview') as HTMLElement;
-      expect(node).toBeInstanceOf(window.HTMLElement);
       expect(node.tagName.toLowerCase()).toBe('webview');
     });
 

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -642,4 +642,50 @@ ul li.specified c.\\:hover img {
       expect(doc.childNodes[1]?.childNodes[1]?.nodeName).toBe('BODY');
     });
   });
+
+  describe('custom element registration', function () {
+    function buildCustomElement(tagName: string) {
+      return buildNodeWithSN(
+        {
+          id: 1,
+          tagName,
+          type: NodeType.Element,
+          attributes: {},
+          childNodes: [],
+          isCustom: true,
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+        },
+      );
+    }
+
+    it.each([
+      ['webview'],
+      ['font-face'],
+      ['annotation-xml'],
+      ['missing-glyph'],
+      ['nohyphen'],
+    ])('does not throw and does not register when tagName is %p', (tagName) => {
+      expect(() => buildCustomElement(tagName)).not.toThrow();
+      expect(window.customElements.get(tagName)).toBeUndefined();
+    });
+
+    it('creates a plain element for invalid custom element names', () => {
+      const node = buildCustomElement('webview') as HTMLElement;
+      expect(node).toBeInstanceOf(window.HTMLElement);
+      expect(node.tagName.toLowerCase()).toBe('webview');
+    });
+
+    it('registers a valid custom element name exactly once', () => {
+      const firstNode = buildCustomElement('my-widget-one') as HTMLElement;
+      const secondNode = buildCustomElement('my-widget-one') as HTMLElement;
+      expect(firstNode).toBeInstanceOf(window.HTMLElement);
+      expect(secondNode).toBeInstanceOf(window.HTMLElement);
+      expect(window.customElements.get('my-widget-one')).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Session replay crashes with `DOMException: "webview" is not a valid custom element name` when a snapshot captured in a context that registered non-spec elements (e.g. Electron's `<webview>`) is replayed in normal Chrome. The recorder flags the element with `isCustom: true`; the replay-side rebuild then calls `customElements.define('webview', ...)` and the synchronous throw aborts the whole rebuild walk.
- Validate the tag name against the HTML PotentialCustomElementName grammar (must contain a hyphen, must start with `[a-z]`) and against the reserved-name set (`annotation-xml`, `color-profile`, `font-face*`, `missing-glyph`) before registering.
- Wrap the `customElements.define` call in try/catch as a belt-and-braces so a future spec edge case can't re-crash replay.

## Test plan

- [x] New parameterised tests in `rebuild.test.ts` cover `webview`, reserved names, and non-hyphen names — none throw, none register.
- [x] Valid names (`my-widget-one`) still register exactly once.
- [x] All 97 `@posthog/rrweb-snapshot` unit tests pass; build clean.
- [ ] Puppeteer-based integration tests require Chrome 131 locally (pre-existing environment issue, unrelated to this change) — will run in CI.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*