### PR TITLE
[codex] Support WebGPU canvas snapshots in rrweb

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas.ts
@@ -13,6 +13,16 @@ type GPUCanvasConfigurationLike = {
   usage?: number;
 };
 
+type GPUTextureUsageLike = {
+  COPY_SRC: number;
+  RENDER_ATTACHMENT: number;
+};
+
+type WebGPUCanvasLike = {
+  nodeType?: number;
+  __context?: string;
+};
+
 type WebGPUCanvasContextLike = {
   canvas?: unknown;
   configure?: (configuration: GPUCanvasConfigurationLike) => void;
@@ -22,14 +32,9 @@ function getNormalizedContextName(contextType: string) {
   return contextType === 'experimental-webgl' ? 'webgl' : contextType;
 }
 
-function getRequiredWebGPUTextureUsage() {
+function getRequiredWebGPUTextureUsage(win: IWindow) {
   const textureUsage = (
-    globalThis as typeof globalThis & {
-      GPUTextureUsage?: {
-        COPY_SRC: number;
-        RENDER_ATTACHMENT: number;
-      };
-    }
+    win as IWindow & { GPUTextureUsage?: GPUTextureUsageLike }
   ).GPUTextureUsage;
 
   if (!textureUsage) {
@@ -41,14 +46,20 @@ function getRequiredWebGPUTextureUsage() {
 
 function getCanvasFromWebGPUContext(
   context: WebGPUCanvasContextLike,
-): ICanvas | HTMLCanvasElement | null {
+): WebGPUCanvasLike | null {
   const { canvas } = context;
 
-  if (!canvas || typeof canvas !== 'object' || !('nodeType' in canvas)) {
+  if (!canvas || typeof canvas !== 'object') {
     return null;
   }
 
-  return canvas as ICanvas | HTMLCanvasElement;
+  return canvas as WebGPUCanvasLike;
+}
+
+function isCanvasNode(
+  canvas: WebGPUCanvasLike,
+): canvas is ICanvas | HTMLCanvasElement {
+  return 'nodeType' in canvas;
 }
 
 function initCanvasWebGPUContextObserver(
@@ -86,13 +97,19 @@ function initCanvasWebGPUContextObserver(
       ) {
         const canvas = getCanvasFromWebGPUContext(this);
 
-        if (!canvas || isBlocked(canvas, blockClass, blockSelector, true)) {
+        if (
+          !canvas ||
+          (isCanvasNode(canvas) &&
+            isBlocked(canvas, blockClass, blockSelector, true))
+        ) {
           return original.call(this, configuration);
         }
 
-        if (!('__context' in canvas)) (canvas as ICanvas).__context = 'webgpu';
+        if (isCanvasNode(canvas) && !('__context' in canvas)) {
+          (canvas as ICanvas).__context = 'webgpu';
+        }
 
-        const requiredUsage = getRequiredWebGPUTextureUsage();
+        const requiredUsage = getRequiredWebGPUTextureUsage(win);
         if (requiredUsage === null || !configuration) {
           return original.call(this, configuration);
         }

--- a/packages/rrweb/src/record/observers/canvas/canvas.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas.ts
@@ -7,8 +7,72 @@ import type {
 import { isBlocked } from '../../../utils';
 import { patch } from '@posthog/rrweb-utils';
 
+const WEBGL_CONTEXT_NAMES = ['webgl', 'webgl2'];
+
+type GPUCanvasConfigurationLike = {
+  usage?: number;
+};
+
+type WebGPUCanvasContextLike = {
+  configure?: (configuration: GPUCanvasConfigurationLike) => void;
+  __rrwebWebGPUConfigurePatched?: boolean;
+};
+
 function getNormalizedContextName(contextType: string) {
   return contextType === 'experimental-webgl' ? 'webgl' : contextType;
+}
+
+function getRequiredWebGPUTextureUsage() {
+  const textureUsage = (
+    globalThis as typeof globalThis & {
+      GPUTextureUsage?: {
+        COPY_SRC: number;
+        RENDER_ATTACHMENT: number;
+      };
+    }
+  ).GPUTextureUsage;
+
+  if (!textureUsage) {
+    return null;
+  }
+
+  return textureUsage.COPY_SRC | textureUsage.RENDER_ATTACHMENT;
+}
+
+function patchWebGPUConfigureForSnapshotting(context: unknown) {
+  if (!context || typeof context !== 'object') {
+    return;
+  }
+
+  const webgpuContext = context as WebGPUCanvasContextLike;
+  if (
+    webgpuContext.__rrwebWebGPUConfigurePatched ||
+    typeof webgpuContext.configure !== 'function'
+  ) {
+    return;
+  }
+
+  const originalConfigure = webgpuContext.configure;
+  webgpuContext.configure = function (
+    this: WebGPUCanvasContextLike,
+    configuration: GPUCanvasConfigurationLike,
+  ) {
+    const requiredUsage = getRequiredWebGPUTextureUsage();
+    if (requiredUsage === null || !configuration) {
+      return originalConfigure.call(this, configuration);
+    }
+
+    return originalConfigure.call(this, {
+      ...configuration,
+      // WebGPU does not implicitly keep RENDER_ATTACHMENT when usage is set,
+      // so include both flags needed for drawing and snapshot reads.
+      usage:
+        typeof configuration.usage === 'number'
+          ? configuration.usage | requiredUsage
+          : requiredUsage,
+    });
+  };
+  webgpuContext.__rrwebWebGPUConfigurePatched = true;
 }
 
 export default function initCanvasContextObserver(
@@ -34,13 +98,13 @@ export default function initCanvasContextObserver(
           contextType: string,
           ...args: Array<unknown>
         ) {
+          const ctxName = getNormalizedContextName(contextType);
           if (!isBlocked(this, blockClass, blockSelector, true)) {
-            const ctxName = getNormalizedContextName(contextType);
             if (!('__context' in this)) (this as ICanvas).__context = ctxName;
 
             if (
               setPreserveDrawingBufferToTrue &&
-              ['webgl', 'webgl2'].includes(ctxName)
+              WEBGL_CONTEXT_NAMES.includes(ctxName)
             ) {
               if (args[0] && typeof args[0] === 'object') {
                 const contextAttributes = args[0] as WebGLContextAttributes;
@@ -54,7 +118,18 @@ export default function initCanvasContextObserver(
               }
             }
           }
-          return original.apply(this, [contextType, ...args]);
+
+          const context = original.apply(this, [contextType, ...args]);
+
+          if (
+            !isBlocked(this, blockClass, blockSelector, true) &&
+            setPreserveDrawingBufferToTrue &&
+            ctxName === 'webgpu'
+          ) {
+            patchWebGPUConfigureForSnapshotting(context);
+          }
+
+          return context;
         };
       },
     );

--- a/packages/rrweb/src/record/observers/canvas/canvas.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas.ts
@@ -14,8 +14,8 @@ type GPUCanvasConfigurationLike = {
 };
 
 type WebGPUCanvasContextLike = {
+  canvas?: unknown;
   configure?: (configuration: GPUCanvasConfigurationLike) => void;
-  __rrwebWebGPUConfigurePatched?: boolean;
 };
 
 function getNormalizedContextName(contextType: string) {
@@ -39,40 +39,76 @@ function getRequiredWebGPUTextureUsage() {
   return textureUsage.COPY_SRC | textureUsage.RENDER_ATTACHMENT;
 }
 
-function patchWebGPUConfigureForSnapshotting(context: unknown) {
-  if (!context || typeof context !== 'object') {
-    return;
+function getCanvasFromWebGPUContext(
+  context: WebGPUCanvasContextLike,
+): ICanvas | HTMLCanvasElement | null {
+  const { canvas } = context;
+
+  if (!canvas || typeof canvas !== 'object' || !('nodeType' in canvas)) {
+    return null;
   }
 
-  const webgpuContext = context as WebGPUCanvasContextLike;
-  if (
-    webgpuContext.__rrwebWebGPUConfigurePatched ||
-    typeof webgpuContext.configure !== 'function'
-  ) {
-    return;
-  }
+  return canvas as ICanvas | HTMLCanvasElement;
+}
 
-  const originalConfigure = webgpuContext.configure;
-  webgpuContext.configure = function (
-    this: WebGPUCanvasContextLike,
-    configuration: GPUCanvasConfigurationLike,
-  ) {
-    const requiredUsage = getRequiredWebGPUTextureUsage();
-    if (requiredUsage === null || !configuration) {
-      return originalConfigure.call(this, configuration);
+function initCanvasWebGPUContextObserver(
+  win: IWindow,
+  blockClass: blockClass,
+  blockSelector: string | null,
+): listenerHandler | undefined {
+  const GPUCanvasContext = (
+    win as IWindow & {
+      GPUCanvasContext?: {
+        prototype?: WebGPUCanvasContextLike;
+      };
     }
+  ).GPUCanvasContext;
 
-    return originalConfigure.call(this, {
-      ...configuration,
-      // WebGPU does not implicitly keep RENDER_ATTACHMENT when usage is set,
-      // so include both flags needed for drawing and snapshot reads.
-      usage:
-        typeof configuration.usage === 'number'
-          ? configuration.usage | requiredUsage
-          : requiredUsage,
-    });
-  };
-  webgpuContext.__rrwebWebGPUConfigurePatched = true;
+  if (
+    !GPUCanvasContext?.prototype ||
+    typeof GPUCanvasContext.prototype.configure !== 'function'
+  ) {
+    return;
+  }
+
+  return patch(
+    GPUCanvasContext.prototype,
+    'configure',
+    function (
+      original: (
+        this: WebGPUCanvasContextLike,
+        configuration: GPUCanvasConfigurationLike,
+      ) => void,
+    ) {
+      return function (
+        this: WebGPUCanvasContextLike,
+        configuration: GPUCanvasConfigurationLike,
+      ) {
+        const canvas = getCanvasFromWebGPUContext(this);
+
+        if (!canvas || isBlocked(canvas, blockClass, blockSelector, true)) {
+          return original.call(this, configuration);
+        }
+
+        if (!('__context' in canvas)) (canvas as ICanvas).__context = 'webgpu';
+
+        const requiredUsage = getRequiredWebGPUTextureUsage();
+        if (requiredUsage === null || !configuration) {
+          return original.call(this, configuration);
+        }
+
+        return original.call(this, {
+          ...configuration,
+          // WebGPU does not implicitly keep RENDER_ATTACHMENT when usage is set,
+          // so include both flags needed for drawing and snapshot reads.
+          usage:
+            typeof configuration.usage === 'number'
+              ? configuration.usage | requiredUsage
+              : requiredUsage,
+        });
+      };
+    },
+  );
 }
 
 export default function initCanvasContextObserver(
@@ -83,6 +119,17 @@ export default function initCanvasContextObserver(
 ): listenerHandler {
   const handlers: listenerHandler[] = [];
   try {
+    if (setPreserveDrawingBufferToTrue) {
+      const restoreWebGPUConfigureHandler = initCanvasWebGPUContextObserver(
+        win,
+        blockClass,
+        blockSelector,
+      );
+      if (restoreWebGPUConfigureHandler) {
+        handlers.push(restoreWebGPUConfigureHandler);
+      }
+    }
+
     const restoreHandler = patch(
       win.HTMLCanvasElement.prototype,
       'getContext',
@@ -119,17 +166,7 @@ export default function initCanvasContextObserver(
             }
           }
 
-          const context = original.apply(this, [contextType, ...args]);
-
-          if (
-            !isBlocked(this, blockClass, blockSelector, true) &&
-            setPreserveDrawingBufferToTrue &&
-            ctxName === 'webgpu'
-          ) {
-            patchWebGPUConfigureForSnapshotting(context);
-          }
-
-          return context;
+          return original.apply(this, [contextType, ...args]);
         };
       },
     );

--- a/packages/rrweb/test/record/canvas-context.test.ts
+++ b/packages/rrweb/test/record/canvas-context.test.ts
@@ -5,6 +5,8 @@ class FakeCanvasElement {
   public nodeType = 1;
   public ELEMENT_NODE = 1;
   public classList = { contains: () => false };
+  public __lastWebGPUConfigure?: { usage?: number };
+  public __webgpuContext?: FakeGPUCanvasContext;
 
   closest() {
     return null;
@@ -14,8 +16,24 @@ class FakeCanvasElement {
     return false;
   }
 
-  getContext(_contextType: string, ..._args: unknown[]) {
+  getContext(contextType: string, ..._args: unknown[]) {
+    if (contextType === 'webgpu') {
+      if (!this.__webgpuContext) {
+        this.__webgpuContext = new FakeGPUCanvasContext(this);
+      }
+
+      return this.__webgpuContext as unknown as RenderingContext;
+    }
+
     return null;
+  }
+}
+
+class FakeGPUCanvasContext {
+  constructor(public canvas: FakeCanvasElement) {}
+
+  configure(configuration: { usage?: number }) {
+    this.canvas.__lastWebGPUConfigure = configuration;
   }
 }
 
@@ -61,21 +79,11 @@ describe('initCanvasContextObserver', () => {
   });
 
   it('adds the snapshot-safe usage flags when webgpu contexts are configured', () => {
-    const configure = vi.fn();
-    const fakeWebGPUContext = { configure };
     const win = {
       HTMLCanvasElement: FakeCanvasElement,
+      GPUCanvasContext: FakeGPUCanvasContext,
     };
-
-    const getContextSpy = vi
-      .spyOn(FakeCanvasElement.prototype, 'getContext')
-      .mockImplementation(((contextType: string) => {
-        if (contextType === 'webgpu') {
-          return fakeWebGPUContext as unknown as RenderingContext;
-        }
-
-        return null;
-      }) as HTMLCanvasElement['getContext']);
+    const getContextSpy = vi.spyOn(FakeCanvasElement.prototype, 'getContext');
 
     const restore = initCanvasContextObserver(
       win as unknown as Parameters<typeof initCanvasContextObserver>[0],
@@ -85,7 +93,7 @@ describe('initCanvasContextObserver', () => {
     );
 
     const canvas = new FakeCanvasElement();
-    const context = canvas.getContext('webgpu') as typeof fakeWebGPUContext;
+    const context = canvas.getContext('webgpu') as FakeGPUCanvasContext;
     const textureUsage = (
       globalThis as typeof globalThis & {
         GPUTextureUsage?: {
@@ -104,7 +112,48 @@ describe('initCanvasContextObserver', () => {
       (canvas as FakeCanvasElement & { __context?: string }).__context,
     ).toBe('webgpu');
     expect(getContextSpy).toHaveBeenCalledWith('webgpu');
-    expect(configure).toHaveBeenCalledWith({
+    expect(canvas.__lastWebGPUConfigure).toEqual({
+      usage:
+        textureUsage.TEXTURE_BINDING |
+        textureUsage.COPY_SRC |
+        textureUsage.RENDER_ATTACHMENT,
+    });
+
+    restore();
+  });
+
+  it('patches webgpu contexts created before the observer starts', () => {
+    const win = {
+      HTMLCanvasElement: FakeCanvasElement,
+      GPUCanvasContext: FakeGPUCanvasContext,
+    };
+    const canvas = new FakeCanvasElement();
+    const context = canvas.getContext('webgpu') as FakeGPUCanvasContext;
+    const textureUsage = (
+      globalThis as typeof globalThis & {
+        GPUTextureUsage?: {
+          COPY_SRC: number;
+          RENDER_ATTACHMENT: number;
+          TEXTURE_BINDING: number;
+        };
+      }
+    ).GPUTextureUsage!;
+
+    const restore = initCanvasContextObserver(
+      win as unknown as Parameters<typeof initCanvasContextObserver>[0],
+      'rr-block',
+      null,
+      true,
+    );
+
+    context.configure({
+      usage: textureUsage.TEXTURE_BINDING,
+    });
+
+    expect(
+      (canvas as FakeCanvasElement & { __context?: string }).__context,
+    ).toBe('webgpu');
+    expect(canvas.__lastWebGPUConfigure).toEqual({
       usage:
         textureUsage.TEXTURE_BINDING |
         textureUsage.COPY_SRC |

--- a/packages/rrweb/test/record/canvas-context.test.ts
+++ b/packages/rrweb/test/record/canvas-context.test.ts
@@ -29,13 +29,27 @@ class FakeCanvasElement {
   }
 }
 
+class FakeOffscreenCanvas {
+  public __lastWebGPUConfigure?: { usage?: number };
+}
+
 class FakeGPUCanvasContext {
-  constructor(public canvas: FakeCanvasElement) {}
+  constructor(public canvas: FakeCanvasElement | FakeOffscreenCanvas) {}
 
   configure(configuration: { usage?: number }) {
     this.canvas.__lastWebGPUConfigure = configuration;
   }
 }
+
+const createFakeWindow = () => ({
+  HTMLCanvasElement: FakeCanvasElement,
+  GPUCanvasContext: FakeGPUCanvasContext,
+  GPUTextureUsage: {
+    COPY_SRC: 0x100,
+    TEXTURE_BINDING: 0x400,
+    RENDER_ATTACHMENT: 0x1000,
+  },
+});
 
 describe('initCanvasContextObserver', () => {
   const originalGPUTextureUsage = (
@@ -79,10 +93,7 @@ describe('initCanvasContextObserver', () => {
   });
 
   it('adds the snapshot-safe usage flags when webgpu contexts are configured', () => {
-    const win = {
-      HTMLCanvasElement: FakeCanvasElement,
-      GPUCanvasContext: FakeGPUCanvasContext,
-    };
+    const win = createFakeWindow();
     const getContextSpy = vi.spyOn(FakeCanvasElement.prototype, 'getContext');
 
     const restore = initCanvasContextObserver(
@@ -94,15 +105,7 @@ describe('initCanvasContextObserver', () => {
 
     const canvas = new FakeCanvasElement();
     const context = canvas.getContext('webgpu') as FakeGPUCanvasContext;
-    const textureUsage = (
-      globalThis as typeof globalThis & {
-        GPUTextureUsage?: {
-          COPY_SRC: number;
-          RENDER_ATTACHMENT: number;
-          TEXTURE_BINDING: number;
-        };
-      }
-    ).GPUTextureUsage!;
+    const { GPUTextureUsage: textureUsage } = win;
 
     context.configure({
       usage: textureUsage.TEXTURE_BINDING,
@@ -123,21 +126,10 @@ describe('initCanvasContextObserver', () => {
   });
 
   it('patches webgpu contexts created before the observer starts', () => {
-    const win = {
-      HTMLCanvasElement: FakeCanvasElement,
-      GPUCanvasContext: FakeGPUCanvasContext,
-    };
+    const win = createFakeWindow();
     const canvas = new FakeCanvasElement();
     const context = canvas.getContext('webgpu') as FakeGPUCanvasContext;
-    const textureUsage = (
-      globalThis as typeof globalThis & {
-        GPUTextureUsage?: {
-          COPY_SRC: number;
-          RENDER_ATTACHMENT: number;
-          TEXTURE_BINDING: number;
-        };
-      }
-    ).GPUTextureUsage!;
+    const { GPUTextureUsage: textureUsage } = win;
 
     const restore = initCanvasContextObserver(
       win as unknown as Parameters<typeof initCanvasContextObserver>[0],
@@ -153,6 +145,33 @@ describe('initCanvasContextObserver', () => {
     expect(
       (canvas as FakeCanvasElement & { __context?: string }).__context,
     ).toBe('webgpu');
+    expect(canvas.__lastWebGPUConfigure).toEqual({
+      usage:
+        textureUsage.TEXTURE_BINDING |
+        textureUsage.COPY_SRC |
+        textureUsage.RENDER_ATTACHMENT,
+    });
+
+    restore();
+  });
+
+  it('patches webgpu contexts backed by offscreen canvases', () => {
+    const win = createFakeWindow();
+    const canvas = new FakeOffscreenCanvas();
+    const context = new FakeGPUCanvasContext(canvas);
+    const { GPUTextureUsage: textureUsage } = win;
+
+    const restore = initCanvasContextObserver(
+      win as unknown as Parameters<typeof initCanvasContextObserver>[0],
+      'rr-block',
+      null,
+      true,
+    );
+
+    context.configure({
+      usage: textureUsage.TEXTURE_BINDING,
+    });
+
     expect(canvas.__lastWebGPUConfigure).toEqual({
       usage:
         textureUsage.TEXTURE_BINDING |

--- a/packages/rrweb/test/record/canvas-context.test.ts
+++ b/packages/rrweb/test/record/canvas-context.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import initCanvasContextObserver from '../../src/record/observers/canvas/canvas';
+
+class FakeCanvasElement {
+  public nodeType = 1;
+  public ELEMENT_NODE = 1;
+  public classList = { contains: () => false };
+
+  closest() {
+    return null;
+  }
+
+  matches() {
+    return false;
+  }
+
+  getContext(_contextType: string, ..._args: unknown[]) {
+    return null;
+  }
+}
+
+describe('initCanvasContextObserver', () => {
+  const originalGPUTextureUsage = (
+    globalThis as typeof globalThis & {
+      GPUTextureUsage?: {
+        COPY_SRC: number;
+        RENDER_ATTACHMENT: number;
+        TEXTURE_BINDING: number;
+      };
+    }
+  ).GPUTextureUsage;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        GPUTextureUsage?: {
+          COPY_SRC: number;
+          RENDER_ATTACHMENT: number;
+          TEXTURE_BINDING: number;
+        };
+      }
+    ).GPUTextureUsage = {
+      COPY_SRC: 0x01,
+      TEXTURE_BINDING: 0x04,
+      RENDER_ATTACHMENT: 0x10,
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    (
+      globalThis as typeof globalThis & {
+        GPUTextureUsage?: {
+          COPY_SRC: number;
+          RENDER_ATTACHMENT: number;
+          TEXTURE_BINDING: number;
+        };
+      }
+    ).GPUTextureUsage = originalGPUTextureUsage;
+  });
+
+  it('adds the snapshot-safe usage flags when webgpu contexts are configured', () => {
+    const configure = vi.fn();
+    const fakeWebGPUContext = { configure };
+    const win = {
+      HTMLCanvasElement: FakeCanvasElement,
+    };
+
+    const getContextSpy = vi
+      .spyOn(FakeCanvasElement.prototype, 'getContext')
+      .mockImplementation(((contextType: string) => {
+        if (contextType === 'webgpu') {
+          return fakeWebGPUContext as unknown as RenderingContext;
+        }
+
+        return null;
+      }) as HTMLCanvasElement['getContext']);
+
+    const restore = initCanvasContextObserver(
+      win as unknown as Parameters<typeof initCanvasContextObserver>[0],
+      'rr-block',
+      null,
+      true,
+    );
+
+    const canvas = new FakeCanvasElement();
+    const context = canvas.getContext('webgpu') as typeof fakeWebGPUContext;
+    const textureUsage = (
+      globalThis as typeof globalThis & {
+        GPUTextureUsage?: {
+          COPY_SRC: number;
+          RENDER_ATTACHMENT: number;
+          TEXTURE_BINDING: number;
+        };
+      }
+    ).GPUTextureUsage!;
+
+    context.configure({
+      usage: textureUsage.TEXTURE_BINDING,
+    });
+
+    expect(
+      (canvas as FakeCanvasElement & { __context?: string }).__context,
+    ).toBe('webgpu');
+    expect(getContextSpy).toHaveBeenCalledWith('webgpu');
+    expect(configure).toHaveBeenCalledWith({
+      usage:
+        textureUsage.TEXTURE_BINDING |
+        textureUsage.COPY_SRC |
+        textureUsage.RENDER_ATTACHMENT,
+    });
+
+    restore();
+  });
+
+  it('leaves other contexts unchanged', () => {
+    const contextAttributes: WebGLContextAttributes = {};
+    const win = {
+      HTMLCanvasElement: FakeCanvasElement,
+    };
+    const getContext = vi
+      .spyOn(FakeCanvasElement.prototype, 'getContext')
+      .mockReturnValue({} as RenderingContext);
+    const restore = initCanvasContextObserver(
+      win as unknown as Parameters<typeof initCanvasContextObserver>[0],
+      'rr-block',
+      null,
+      true,
+    );
+
+    const canvas = new FakeCanvasElement();
+    canvas.getContext('webgl', contextAttributes);
+
+    expect(
+      (canvas as FakeCanvasElement & { __context?: string }).__context,
+    ).toBe('webgl');
+    expect(contextAttributes.preserveDrawingBuffer).toBe(true);
+    expect(getContext).toHaveBeenCalledWith('webgl', contextAttributes);
+
+    restore();
+  });
+});

--- a/packages/rrweb/test/record/webgpu.test.ts
+++ b/packages/rrweb/test/record/webgpu.test.ts
@@ -1,0 +1,198 @@
+import * as path from 'path';
+import type * as puppeteer from 'puppeteer';
+import { describe, expect, it, vi } from 'vitest';
+import type { recordOptions } from '../../src/types';
+import {
+  listenerHandler,
+  eventWithTime,
+  EventType,
+  IncrementalSource,
+  CanvasContext,
+} from '@posthog/rrweb-types';
+import { launchPuppeteer, waitForCondition } from '../utils';
+
+interface ISuite {
+  browser: puppeteer.Browser;
+  page: puppeteer.Page;
+  events: eventWithTime[];
+}
+
+interface IWindow extends Window {
+  rrweb: {
+    record: (
+      options: recordOptions<eventWithTime>,
+    ) => listenerHandler | undefined;
+  };
+  emit: (e: eventWithTime) => undefined;
+}
+
+const setup = function (this: ISuite, content: string): ISuite {
+  const ctx = {} as ISuite;
+
+  beforeAll(async () => {
+    ctx.browser = await launchPuppeteer({
+      args: ['--no-sandbox', '--enable-unsafe-webgpu'],
+    });
+  });
+
+  beforeEach(async () => {
+    ctx.page = await ctx.browser.newPage();
+    await ctx.page.goto('about:blank');
+    await ctx.page.setContent(content);
+
+    await ctx.page.evaluate(() => {
+      (
+        globalThis as typeof globalThis & {
+          GPUTextureUsage?: {
+            COPY_SRC: number;
+            TEXTURE_BINDING: number;
+            RENDER_ATTACHMENT: number;
+          };
+          __originalCreateImageBitmap?: typeof createImageBitmap;
+        }
+      ).GPUTextureUsage = {
+        COPY_SRC: 0x01,
+        TEXTURE_BINDING: 0x04,
+        RENDER_ATTACHMENT: 0x10,
+      };
+
+      const originalGetContext = HTMLCanvasElement.prototype.getContext;
+      HTMLCanvasElement.prototype.getContext = function (
+        contextType: string,
+        ...args: unknown[]
+      ) {
+        if (contextType === 'webgpu') {
+          const canvas = this as HTMLCanvasElement & {
+            __lastWebGPUConfigure?: { usage?: number };
+          };
+
+          return {
+            configure(configuration: { usage?: number }) {
+              canvas.__lastWebGPUConfigure = configuration;
+            },
+          } as unknown as RenderingContext;
+        }
+
+        return originalGetContext.call(this, contextType, ...args);
+      };
+
+      const originalCreateImageBitmap = createImageBitmap.bind(window);
+      (
+        globalThis as typeof globalThis & {
+          __originalCreateImageBitmap?: typeof createImageBitmap;
+        }
+      ).__originalCreateImageBitmap = originalCreateImageBitmap;
+      window.createImageBitmap = async () => {
+        const source = document.createElement('canvas');
+        source.width = 4;
+        source.height = 4;
+        const sourceContext = source.getContext('2d')!;
+        sourceContext.fillStyle = 'rgb(0, 128, 0)';
+        sourceContext.fillRect(0, 0, 4, 4);
+        return await originalCreateImageBitmap(source);
+      };
+    });
+
+    await ctx.page.addScriptTag({
+      path: path.resolve(__dirname, '../../dist/rrweb.umd.cjs'),
+    });
+    ctx.events = [];
+    await ctx.page.exposeFunction('emit', (e: eventWithTime) => {
+      if (e.type === EventType.DomContentLoaded || e.type === EventType.Load) {
+        return;
+      }
+      ctx.events.push(e);
+    });
+
+    await ctx.page.evaluate(() => {
+      const { record } = (window as unknown as IWindow).rrweb;
+      record({
+        recordCanvas: true,
+        sampling: {
+          canvas: 60,
+        },
+        emit: (window as unknown as IWindow).emit,
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await ctx.page.close();
+  });
+
+  afterAll(async () => {
+    await ctx.browser?.close();
+  });
+
+  return ctx;
+};
+
+describe('record webgpu snapshots', function (this: ISuite) {
+  vi.setConfig({ testTimeout: 100_000 });
+
+  const ctx: ISuite = setup.call(
+    this,
+    `
+      <!DOCTYPE html>
+      <html>
+        <body>
+          <canvas id="canvas" width="8" height="8" style="width: 8px; height: 8px;"></canvas>
+        </body>
+      </html>
+    `,
+  );
+
+  it('records a replayable snapshot event for webgpu canvases', async () => {
+    const configuredUsage = await ctx.page.evaluate(() => {
+      const canvas = document.getElementById('canvas') as HTMLCanvasElement & {
+        __lastWebGPUConfigure?: { usage?: number };
+      };
+      const textureUsage = (
+        globalThis as typeof globalThis & {
+          GPUTextureUsage: {
+            COPY_SRC: number;
+            TEXTURE_BINDING: number;
+            RENDER_ATTACHMENT: number;
+          };
+        }
+      ).GPUTextureUsage;
+
+      const context = canvas.getContext('webgpu') as {
+        configure: (configuration: { usage?: number }) => void;
+      };
+      context.configure({
+        usage: textureUsage.TEXTURE_BINDING,
+      });
+
+      return canvas.__lastWebGPUConfigure?.usage ?? null;
+    });
+
+    expect(configuredUsage).toBe(0x15);
+
+    const snapshotEvent = await waitForCondition(() =>
+      ctx.events.find(
+        (event) =>
+          event.type === EventType.IncrementalSnapshot &&
+          event.data.source === IncrementalSource.CanvasMutation &&
+          event.data.type === CanvasContext['2D'],
+      ),
+    );
+
+    expect(snapshotEvent).toMatchObject({
+      data: {
+        source: IncrementalSource.CanvasMutation,
+        type: CanvasContext['2D'],
+        displayWidth: 8,
+        displayHeight: 8,
+        commands: [
+          {
+            property: 'clearRect',
+          },
+          {
+            property: 'drawImage',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/rrweb/test/record/webgpu.test.ts
+++ b/packages/rrweb/test/record/webgpu.test.ts
@@ -41,6 +41,19 @@ const setup = function (this: ISuite, content: string): ISuite {
     await ctx.page.setContent(content);
 
     await ctx.page.evaluate(() => {
+      class FakeGPUCanvasContext {
+        constructor(
+          public canvas: HTMLCanvasElement & {
+            __lastWebGPUConfigure?: { usage?: number };
+            __fakeWebGPUContext?: FakeGPUCanvasContext;
+          },
+        ) {}
+
+        configure(configuration: { usage?: number }) {
+          this.canvas.__lastWebGPUConfigure = configuration;
+        }
+      }
+
       (
         globalThis as typeof globalThis & {
           GPUTextureUsage?: {
@@ -48,13 +61,20 @@ const setup = function (this: ISuite, content: string): ISuite {
             TEXTURE_BINDING: number;
             RENDER_ATTACHMENT: number;
           };
+          GPUCanvasContext?: typeof FakeGPUCanvasContext;
           __originalCreateImageBitmap?: typeof createImageBitmap;
+          __preExistingWebGPUContext?: FakeGPUCanvasContext;
         }
       ).GPUTextureUsage = {
         COPY_SRC: 0x01,
         TEXTURE_BINDING: 0x04,
         RENDER_ATTACHMENT: 0x10,
       };
+      (
+        globalThis as typeof globalThis & {
+          GPUCanvasContext?: typeof FakeGPUCanvasContext;
+        }
+      ).GPUCanvasContext = FakeGPUCanvasContext;
 
       const originalGetContext = HTMLCanvasElement.prototype.getContext;
       HTMLCanvasElement.prototype.getContext = function (
@@ -64,17 +84,29 @@ const setup = function (this: ISuite, content: string): ISuite {
         if (contextType === 'webgpu') {
           const canvas = this as HTMLCanvasElement & {
             __lastWebGPUConfigure?: { usage?: number };
+            __fakeWebGPUContext?: FakeGPUCanvasContext;
           };
 
-          return {
-            configure(configuration: { usage?: number }) {
-              canvas.__lastWebGPUConfigure = configuration;
-            },
-          } as unknown as RenderingContext;
+          if (!canvas.__fakeWebGPUContext) {
+            canvas.__fakeWebGPUContext = new FakeGPUCanvasContext(canvas);
+          }
+
+          return canvas.__fakeWebGPUContext as unknown as RenderingContext;
         }
 
         return originalGetContext.call(this, contextType, ...args);
       };
+
+      const canvas = document.getElementById('canvas') as HTMLCanvasElement & {
+        __fakeWebGPUContext?: FakeGPUCanvasContext;
+      };
+      (
+        globalThis as typeof globalThis & {
+          __preExistingWebGPUContext?: FakeGPUCanvasContext;
+        }
+      ).__preExistingWebGPUContext = canvas.getContext(
+        'webgpu',
+      ) as unknown as FakeGPUCanvasContext;
 
       const originalCreateImageBitmap = createImageBitmap.bind(window);
       (
@@ -82,14 +114,32 @@ const setup = function (this: ISuite, content: string): ISuite {
           __originalCreateImageBitmap?: typeof createImageBitmap;
         }
       ).__originalCreateImageBitmap = originalCreateImageBitmap;
-      window.createImageBitmap = async () => {
-        const source = document.createElement('canvas');
-        source.width = 4;
-        source.height = 4;
-        const sourceContext = source.getContext('2d')!;
+      window.createImageBitmap = async (source) => {
+        const sourceCanvas = source as HTMLCanvasElement & {
+          __lastWebGPUConfigure?: { usage?: number };
+          __fakeWebGPUContext?: FakeGPUCanvasContext;
+        };
+
+        if (sourceCanvas.__fakeWebGPUContext) {
+          const requiredUsage =
+            GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT;
+          const configuredUsage = sourceCanvas.__lastWebGPUConfigure?.usage;
+
+          if (
+            typeof configuredUsage !== 'number' ||
+            (configuredUsage & requiredUsage) !== requiredUsage
+          ) {
+            throw new Error('WebGPU canvas missing snapshot-safe usage');
+          }
+        }
+
+        const bitmapSourceCanvas = document.createElement('canvas');
+        bitmapSourceCanvas.width = 4;
+        bitmapSourceCanvas.height = 4;
+        const sourceContext = bitmapSourceCanvas.getContext('2d')!;
         sourceContext.fillStyle = 'rgb(0, 128, 0)';
         sourceContext.fillRect(0, 0, 4, 4);
-        return await originalCreateImageBitmap(source);
+        return await originalCreateImageBitmap(bitmapSourceCanvas);
       };
     });
 
@@ -142,10 +192,11 @@ describe('record webgpu snapshots', function (this: ISuite) {
     `,
   );
 
-  it('records a replayable snapshot event for webgpu canvases', async () => {
-    const configuredUsage = await ctx.page.evaluate(() => {
+  it('records a replayable snapshot event for webgpu contexts created before recording starts', async () => {
+    const { configuredUsage, contextName } = await ctx.page.evaluate(() => {
       const canvas = document.getElementById('canvas') as HTMLCanvasElement & {
         __lastWebGPUConfigure?: { usage?: number };
+        __context?: string;
       };
       const textureUsage = (
         globalThis as typeof globalThis & {
@@ -154,20 +205,31 @@ describe('record webgpu snapshots', function (this: ISuite) {
             TEXTURE_BINDING: number;
             RENDER_ATTACHMENT: number;
           };
+          __preExistingWebGPUContext?: {
+            configure: (configuration: { usage?: number }) => void;
+          };
         }
       ).GPUTextureUsage;
 
-      const context = canvas.getContext('webgpu') as {
-        configure: (configuration: { usage?: number }) => void;
-      };
+      const context = (
+        globalThis as typeof globalThis & {
+          __preExistingWebGPUContext?: {
+            configure: (configuration: { usage?: number }) => void;
+          };
+        }
+      ).__preExistingWebGPUContext!;
       context.configure({
         usage: textureUsage.TEXTURE_BINDING,
       });
 
-      return canvas.__lastWebGPUConfigure?.usage ?? null;
+      return {
+        configuredUsage: canvas.__lastWebGPUConfigure?.usage ?? null,
+        contextName: canvas.__context ?? null,
+      };
     });
 
     expect(configuredUsage).toBe(0x15);
+    expect(contextName).toBe('webgpu');
 
     const snapshotEvent = await waitForCondition(() =>
       ctx.events.find(


### PR DESCRIPTION
## Summary
- patch rrweb's WebGPU snapshot path by wrapping `GPUCanvasContext.prototype.configure()` while canvas FPS recording is active
- read WebGPU constants from the observed `win` instead of `globalThis`, so same-origin iframes and popups use the correct window globals
- keep `getContext('webgpu')` tagging for DOM canvases, while also allowing OffscreenCanvas-backed WebGPU contexts to receive the snapshot-safe usage flags
- add focused regression tests for the observer hook and browser recording path

## Root Cause
PostHog session replay's canvas FPS path records image snapshots via `createImageBitmap(canvas, ...)`. For WebGPU canvases, rrweb was not preserving the texture usage flags required for readback, so WebGPU canvases could render correctly in-app while failing to show their pixels in replay captures.

The first version of this PR only wrapped `configure()` on WebGPU contexts returned after rrweb patched `HTMLCanvasElement.prototype.getContext`, which missed the common startup path where apps obtain a WebGPU context before calling `record()`. This update moves the hook to `GPUCanvasContext.prototype.configure()` so pre-existing contexts are covered as long as they are configured after recording starts.

## Impact
This keeps normal WebGPU rendering intact while making rrweb's snapshot-based canvas capture work for:
- WebGPU canvases created after recording starts
- WebGPU contexts created before recording starts but configured after recording starts
- WebGPU contexts in same-origin child windows that have their own WebGPU globals
- OffscreenCanvas-backed WebGPU contexts that still need snapshot-safe usage flags

Remaining limitation:
- canvases that were already configured before recording starts still cannot be retroactively fixed unless the app configures them again while rrweb is active

## Validation
- `PUPPETEER_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm --filter @posthog/rrweb exec vitest run test/record/canvas-context.test.ts test/record/canvas-manager.test.ts test/record/webgpu.test.ts test/record/webgl.test.ts`
- `pnpm turbo run prepublish --filter=@posthog/rrweb`
- `git diff --check`

## Live Browser Proof
Verified in a real Chrome DevTools browser session against the built rrweb bundle:
- `navigator.gpu` and `requestAdapter()` succeeded
- a WebGPU canvas requested usage `4` (`TEXTURE_BINDING`)
- rrweb upgraded the actual `GPUCanvasContext.configure()` usage to `21` (`TEXTURE_BINDING | COPY_SRC | RENDER_ATTACHMENT`)
- rrweb emitted replayable 2D canvas snapshot events with `clearRect` and `drawImage` commands for the WebGPU canvas
