### PR TITLE
fix: handle SecurityError in IframeManager.attachIframe

### DIFF
--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -114,18 +114,20 @@ export class IframeManager {
     ) {
       const nestedHandler = this.handleMessage.bind(this);
       this.nestedIframeListeners.set(win, nestedHandler);
-      win.addEventListener('message', nestedHandler);
+      callSafely(() => win.addEventListener('message', nestedHandler));
     }
 
-    iframeEl.contentWindow?.addEventListener('pagehide', () => {
-      this.pageHideListener?.(iframeEl);
-      if (iframeEl.contentDocument) {
-        this.mirror.removeNodeFromMap(iframeEl.contentDocument);
-      }
-      if (iframeEl.contentWindow) {
-        this.crossOriginIframeMap.delete(iframeEl.contentWindow);
-      }
-    });
+    callSafely(() =>
+      iframeEl.contentWindow?.addEventListener('pagehide', () => {
+        this.pageHideListener?.(iframeEl);
+        if (iframeEl.contentDocument) {
+          this.mirror.removeNodeFromMap(iframeEl.contentDocument);
+        }
+        if (iframeEl.contentWindow) {
+          this.crossOriginIframeMap.delete(iframeEl.contentWindow);
+        }
+      }),
+    );
 
     this.loadListener?.(iframeEl);
 

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -113,8 +113,10 @@ export class IframeManager {
       !this.nestedIframeListeners.has(win)
     ) {
       const nestedHandler = this.handleMessage.bind(this);
-      this.nestedIframeListeners.set(win, nestedHandler);
-      callSafely(() => win.addEventListener('message', nestedHandler));
+      callSafely(() => {
+        win.addEventListener('message', nestedHandler);
+        this.nestedIframeListeners.set(win, nestedHandler);
+      });
     }
 
     callSafely(() =>

--- a/packages/rrweb/test/record/memory-leaks.test.ts
+++ b/packages/rrweb/test/record/memory-leaks.test.ts
@@ -623,6 +623,49 @@ describe('memory leak prevention', () => {
         }
       },
     );
+
+    it('attachIframe should not throw and should still invoke loadListener when contentWindow.addEventListener throws SecurityError', () => {
+      const { iframeManager, mirror } = createIframeManager();
+      const loadListener = vi.fn();
+      iframeManager.addLoadListener(loadListener);
+
+      const win = new Proxy(
+        {},
+        {
+          get(_target, prop) {
+            if (prop === 'addEventListener') {
+              throw new DOMException(
+                "Failed to read a named property 'addEventListener' from 'Window': Blocked a frame with origin",
+                'SecurityError',
+              );
+            }
+            return undefined;
+          },
+        },
+      ) as unknown as Window;
+
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      Object.defineProperty(iframe, 'contentWindow', { get: () => win });
+      mirror.add(iframe, {
+        type: 2,
+        tagName: 'iframe',
+        attributes: {},
+        childNodes: [],
+        id: 101,
+      });
+
+      expect(() =>
+        iframeManager.attachIframe(iframe, {
+          type: 0,
+          childNodes: [],
+          id: 201,
+        } as any),
+      ).not.toThrow();
+      expect(loadListener).toHaveBeenCalledWith(iframe);
+
+      document.body.removeChild(iframe);
+    });
   });
 
   describe('iframe observer cleanup', () => {


### PR DESCRIPTION
## Problem

When a page contains a cross-origin iframe, `IframeManager.attachIframe` calls `addEventListener` on `iframeEl.contentWindow`, which throws `DOMException: SecurityError`. The exception escapes to the outer `try/catch` in `record()`, which only logs a warning and returns early, before DOM observers are attached and before `recording = true`. As a result, zero snapshots were captured for the entire session, even though the page was otherwise recordable.

## Changes

- Wrap both `contentWindow.addEventListener` calls in `attachIframe` with the existing `callSafely` helper so cross-origin `SecurityError` are swallowed and the rest of recorder init continues.
- Add a regression test asserting that `attachIframe` does not throw and still invokes the registered `loadListener` when `addEventListener` throws `SecurityError`.
